### PR TITLE
feat: :wheelchair: add `styles` for `audio` with `controls` attribute

### DIFF
--- a/src/mixins/_reset-zone-styles.scss
+++ b/src/mixins/_reset-zone-styles.scss
@@ -727,6 +727,30 @@
       }
     }
 
+    // * Hide audio elements that do not have a controls attribute.
+    // * This is useful for preventing audio elements from being rendered
+    // * when they do not have any visible controls.
+    // *
+    // * The :not pseudo-class is used to select all audio elements that
+    // * do not have a controls attribute. The [controls] attribute is
+    // * used to indicate that the audio element should have visible controls.
+    // *
+    // * The display property is set to none to hide the audio element.
+    // *
+    // * For more information on the :not pseudo-class, see the following
+    // * resources:
+    // * - https://developer.mozilla.org/en-US/docs/Web/CSS/:not
+    // *
+    // * For more information on the controls attribute, see the following
+    // * resources:
+    // * - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
+
+    audio {
+      :not([controls]) {
+        display: none;
+      }
+    }
+
     // * The focus-visible pseudo-class is supported in modern browsers.
     // * It is used to indicate if the browser is currently allowing the
     // * user to focus on the element.


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `styles` for `controls`'s `audio` to hide the `audio` itself when the element did not has `controls` attribute.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
