### PR TITLE
Add `$layer-name` parameter for `reset-zone-layer` mixin

### DIFF
--- a/src/reset-zone.layer.scss
+++ b/src/reset-zone.layer.scss
@@ -21,8 +21,19 @@
 
 // @repository: https://github.com/Black-Axis/reset-zone
 
-@mixin reset-zone-layer() {
-  @layer reset-zone {
+// @param {String} $layer-name - The name of the layer.
+// @default reset-zone
+
+// @example 1
+// @include reset-zone-layer;
+
+// @example 2
+// @include reset-zone-layer('general-reset');
+
+@mixin reset-zone-layer($layer-name: reset-zone) {
+  @layer #{$layer-name} {
     @include Core.reset-zone;
   }
 }
+
+@include reset-zone-layer;

--- a/src/reset-zone.layer.scss
+++ b/src/reset-zone.layer.scss
@@ -35,5 +35,3 @@
     @include Core.reset-zone;
   }
 }
-
-@include reset-zone-layer;


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `$layer-name` as a parameter for `reset-zone-layer` mixin to make the user feels free to customize the name of the layer.
- Add `documentation` for the new previous feature.
- Remove the unneeded line for calling the `reset-zone-layer` mixin.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
